### PR TITLE
docs(planton.ai/docs): add author+tags; set author title to Founder & CEO

### DIFF
--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -3,6 +3,19 @@ title: "Getting Started"
 description: "Your starting point for using Planton Cloud — CLI-first quickstart, sources, and next steps."
 icon: rocket
 order: 1
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Getting Started
+  - CLI
+  - Quickstart
 ---
 
 # Planton Documentation

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -5,13 +5,17 @@ icon: welcome
 order: 0
 author:
   - name: Swarup Donepudi
-    title: Technical Content Lead
+    title: Founder & CEO
     bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
     profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
     twitter: https://x.com/swarupdonepudi
     github: https://github.com/swarupdonepudi
     linkedin: https://www.linkedin.com/in/swarupdonepudi
 
+tags:
+  - Overview
+  - Introduction
+  - Welcome
 ---
 
 # Welcome to PlantonCloud!

--- a/content/docs/infra-hub/credentials-and-mappings.mdx
+++ b/content/docs/infra-hub/credentials-and-mappings.mdx
@@ -3,6 +3,19 @@ title: "Credentials and Mappings"
 description: "Secure cloud provider authentication with smart credential mapping across environments"
 icon: key
 order: 60
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Security
+  - Credentials
+  - InfraHub
 ---
 
 # Credentials and Mappings

--- a/content/docs/infra-hub/deployment-components.mdx
+++ b/content/docs/infra-hub/deployment-components.mdx
@@ -3,6 +3,19 @@ title: "Deployment Components"
 description: "Explore the catalog of pre-built cloud resources ready to deploy across AWS, GCP, Azure, and Kubernetes"
 icon: guide
 order: 40
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Catalog
+  - Components
+  - InfraHub
 ---
 
 # Deployment Components

--- a/content/docs/infra-hub/flow-control.mdx
+++ b/content/docs/infra-hub/flow-control.mdx
@@ -3,6 +3,19 @@ title: "Flow Control"
 description: "Master deployment workflows with policies that govern how Stack Jobs execute across your infrastructure"
 icon: guide
 order: 50
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Governance
+  - Policies
+  - InfraHub
 ---
 
 # Flow Control

--- a/content/docs/infra-hub/getting-started.mdx
+++ b/content/docs/infra-hub/getting-started.mdx
@@ -3,6 +3,19 @@ title: "Getting Started with InfraHub"
 description: "Deploy your first cloud resource on Planton Cloud in under 5 minutes"
 icon: guide
 order: 20
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Tutorial
+  - Getting Started
+  - InfraHub
 ---
 
 # Getting Started with InfraHub

--- a/content/docs/infra-hub/index.mdx
+++ b/content/docs/infra-hub/index.mdx
@@ -3,6 +3,19 @@ title: "InfraHub"
 description: "Deploy and manage cloud infrastructure with declarative configurations and automated workflows"
 icon: cloud
 order: 30
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Overview
+  - InfraHub
+  - Infrastructure
 ---
 
 # InfraHub

--- a/content/docs/infra-hub/stack-jobs.mdx
+++ b/content/docs/infra-hub/stack-jobs.mdx
@@ -3,6 +3,19 @@ title: "Stack Jobs Deep Dive"
 description: "Advanced guide to Stack Job execution, optimization, and troubleshooting in Planton Cloud"
 icon: pipeline
 order: 30
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Stack Jobs
+  - Deep Dive
+  - InfraHub
 ---
 
 # Stack Jobs Deep Dive

--- a/content/docs/infra-hub/what-is-a-stack-job.mdx
+++ b/content/docs/infra-hub/what-is-a-stack-job.mdx
@@ -3,6 +3,19 @@ title: "What is a Stack Job?"
 description: "Understanding Stack Jobs - the core execution unit that powers infrastructure deployments in Planton Cloud"
 icon: guide
 order: 10
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Concepts
+  - Stack Jobs
+  - InfraHub
 ---
 
 # What is a Stack Job?

--- a/content/docs/service-hub/getting-started.mdx
+++ b/content/docs/service-hub/getting-started.mdx
@@ -5,7 +5,7 @@ icon: guide
 order: 20
 author:
   - name: Swarup Donepudi
-    title: Technical Content Lead
+    title: Founder & CEO
     bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
     profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
     twitter: https://x.com/swarupdonepudi

--- a/content/docs/service-hub/index.mdx
+++ b/content/docs/service-hub/index.mdx
@@ -3,6 +3,19 @@ title: "ServiceHub"
 description: "Build, deploy, and manage your services with a Vercel-like experience for backend applications"
 icon: service
 order: 40
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Overview
+  - ServiceHub
+  - Deployments
 ---
 
 ## Your Command Center for Modern Application Delivery

--- a/content/docs/service-hub/pipelines.mdx
+++ b/content/docs/service-hub/pipelines.mdx
@@ -3,6 +3,19 @@ title: "Understanding Pipelines"
 description: "Deep dive into how Planton Cloud builds and deploys your services"
 icon: pipeline
 order: 30
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Pipelines
+  - CI/CD
+  - ServiceHub
 ---
 
 ## Your Code's Journey from Commit to Cloud

--- a/content/docs/service-hub/what-is-a-service.mdx
+++ b/content/docs/service-hub/what-is-a-service.mdx
@@ -3,6 +3,19 @@ title: "What is a Service?"
 description: "Understanding Services in Planton Cloud - your gateway to automated builds and deployments"
 icon: guide
 order: 10
+author:
+  - name: Swarup Donepudi
+    title: Founder & CEO
+    bio: "Passionate about developer experience and open source hardware. Building tools that make developers smile."
+    profilePicture: "https://api.dicebear.com/7.x/avataaars/svg?seed=SwarupDonepudi"
+    twitter: https://x.com/swarupdonepudi
+    github: https://github.com/swarupdonepudi
+    linkedin: https://www.linkedin.com/in/swarupdonepudi
+
+tags:
+  - Concepts
+  - Services
+  - ServiceHub
 ---
 
 ## Think of Services Like Your Apps on Vercel, But Better


### PR DESCRIPTION
Summary:
- Add author block and tags to docs pages
- Update author title to Founder & CEO

Scope:
- content/docs/** (InfraHub + ServiceHub)

Notes:
- Consistent metadata across docs.